### PR TITLE
feat: 주문 생성 API 구현 (#27)

### DIFF
--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/entity/Order.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/entity/Order.java
@@ -1,9 +1,7 @@
 package com.gridsandcircles.gc_coffee.entity;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -12,6 +10,8 @@ import java.util.List;
 @Entity
 @Table(name = "orders")
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Order {
 

--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/entity/OrderItem.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/entity/OrderItem.java
@@ -24,4 +24,8 @@ public class OrderItem {
 
     @Column(nullable = false)
     private int quantity;
+
+    public void assignOrder(Order order) {
+        this.order = order;
+    }
 }

--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/entity/OrderItem.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/entity/OrderItem.java
@@ -1,12 +1,12 @@
 package com.gridsandcircles.gc_coffee.entity;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OrderItem {
 

--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/global/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
 
     // 주문
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER_NOT_FOUND", "주문을 찾을 수 없습니다"),
+    ORDER_BATCH_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER_BATCH_NOT_FOUND", "배송 회차를 찾을 수 없습니다"),
 
     // 고객
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_NOT_FOUND", "고객을 찾을 수 없습니다");

--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/order/controller/OrderController.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/order/controller/OrderController.java
@@ -1,0 +1,22 @@
+package com.gridsandcircles.gc_coffee.order.controller;
+
+import com.gridsandcircles.gc_coffee.order.dto.OrderCreateReq;
+import com.gridsandcircles.gc_coffee.order.service.OrderService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/orders")
+@RequiredArgsConstructor
+public class OrderController {
+
+    private final OrderService orderService;
+
+    @PostMapping
+    public ResponseEntity<Long> createOrder(@RequestBody @Valid OrderCreateReq req) {
+        Long orderId = orderService.createOrder(req);
+        return ResponseEntity.ok(orderId);
+    }
+}

--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/order/controller/OrderController.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/order/controller/OrderController.java
@@ -1,5 +1,6 @@
 package com.gridsandcircles.gc_coffee.order.controller;
 
+import com.gridsandcircles.gc_coffee.global.dto.ApiResponse;
 import com.gridsandcircles.gc_coffee.order.dto.OrderCreateRequest;
 import com.gridsandcircles.gc_coffee.order.service.OrderService;
 import jakarta.validation.Valid;
@@ -15,8 +16,9 @@ public class OrderController {
     private final OrderService orderService;
 
     @PostMapping
-    public ResponseEntity<Long> createOrder(@RequestBody @Valid OrderCreateRequest req) {
+    public ApiResponse<Long> createOrder(@RequestBody @Valid OrderCreateRequest req) {
         Long orderId = orderService.createOrder(req);
-        return ResponseEntity.ok(orderId);
+
+        return ApiResponse.ok(orderId);
     }
 }

--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/order/controller/OrderController.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/order/controller/OrderController.java
@@ -1,6 +1,6 @@
 package com.gridsandcircles.gc_coffee.order.controller;
 
-import com.gridsandcircles.gc_coffee.order.dto.OrderCreateReq;
+import com.gridsandcircles.gc_coffee.order.dto.OrderCreateRequest;
 import com.gridsandcircles.gc_coffee.order.service.OrderService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +15,7 @@ public class OrderController {
     private final OrderService orderService;
 
     @PostMapping
-    public ResponseEntity<Long> createOrder(@RequestBody @Valid OrderCreateReq req) {
+    public ResponseEntity<Long> createOrder(@RequestBody @Valid OrderCreateRequest req) {
         Long orderId = orderService.createOrder(req);
         return ResponseEntity.ok(orderId);
     }

--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/order/dto/OrderCreateReq.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/order/dto/OrderCreateReq.java
@@ -1,0 +1,26 @@
+package com.gridsandcircles.gc_coffee.order.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public record OrderCreateReq(
+        @NotBlank(message = "이메일은 필수입니다")
+        @Email(message = "올바른 이메일 형식이 아닙니다")
+        String email,
+
+        @NotBlank(message = "배송 주소는 필수입니다")
+        String address,
+
+        @NotBlank(message = "우편번호는 필수입니다")
+        String zipCode,
+
+        @NotEmpty(message = "상품을 최소 1개 이상 선택해야 합니다")
+        List<OrderItemReq> orderItems
+) {
+    public record OrderItemReq(
+            Long productId,
+            int quantity
+    ) {}
+}

--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/order/dto/OrderCreateRequest.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/order/dto/OrderCreateRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
 
-public record OrderCreateReq(
+public record OrderCreateRequest(
         @NotBlank(message = "이메일은 필수입니다")
         @Email(message = "올바른 이메일 형식이 아닙니다")
         String email,

--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/order/repository/OrderRepository.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/order/repository/OrderRepository.java
@@ -1,0 +1,7 @@
+package com.gridsandcircles.gc_coffee.order.repository;
+
+import com.gridsandcircles.gc_coffee.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/order/service/OrderService.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/order/service/OrderService.java
@@ -1,7 +1,7 @@
 package com.gridsandcircles.gc_coffee.order.service;
 
 import com.gridsandcircles.gc_coffee.entity.*;
-import com.gridsandcircles.gc_coffee.order.dto.OrderCreateReq;
+import com.gridsandcircles.gc_coffee.order.dto.OrderCreateRequest;
 import com.gridsandcircles.gc_coffee.order.repository.OrderRepository;
 import com.gridsandcircles.gc_coffee.order.repository.OrderBatchRepository;
 import com.gridsandcircles.gc_coffee.product.repository.ProductRepository;
@@ -27,7 +27,7 @@ public class OrderService {
     private final OrderBatchRepository orderBatchRepository;
 
     @Transactional
-    public Long createOrder(OrderCreateReq req) {
+    public Long createOrder(OrderCreateRequest req) {
         // 1. 배송 회차 조회
         OrderBatch orderBatch = orderBatchRepository.findById(1L)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_BATCH_NOT_FOUND));
@@ -38,7 +38,7 @@ public class OrderService {
         List<OrderItem> orderItems = new ArrayList<>();
 
         // 3. 주문 상세 항목 생성
-        for (OrderCreateReq.OrderItemReq itemReq : req.orderItems()) {
+        for (OrderCreateRequest.OrderItemReq itemReq : req.orderItems()) {
             Product product = productRepository.findById(itemReq.productId())
                     .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
 

--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/order/service/OrderService.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/order/service/OrderService.java
@@ -1,11 +1,20 @@
 package com.gridsandcircles.gc_coffee.order.service;
 
+import com.gridsandcircles.gc_coffee.entity.*;
+import com.gridsandcircles.gc_coffee.order.dto.OrderCreateReq;
 import com.gridsandcircles.gc_coffee.order.repository.OrderRepository;
+import com.gridsandcircles.gc_coffee.order.repository.OrderBatchRepository;
 import com.gridsandcircles.gc_coffee.product.repository.ProductRepository;
-import com.gridsandcircles.gc_coffee.member.repository.MemberRepository;
+//import com.gridsandcircles.gc_coffee.member.repository.MemberRepository;
+import com.gridsandcircles.gc_coffee.global.exception.BusinessException;
+import com.gridsandcircles.gc_coffee.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.ArrayList;
 
 @Service
 @RequiredArgsConstructor
@@ -14,13 +23,52 @@ public class OrderService {
 
     private final OrderRepository orderRepository;
     private final ProductRepository productRepository;
-    private final MemberRepository memberRepository;
+//    private final MemberRepository memberRepository;
+    private final OrderBatchRepository orderBatchRepository;
 
     @Transactional
-    public Long createOrder() {
-        return null;
-    }
+    public Long createOrder(OrderCreateReq req) {
+        // 1. 배송 회차 조회
+        OrderBatch orderBatch = orderBatchRepository.findById(1L)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_BATCH_NOT_FOUND));
 
-    public void getOrderDetails(Long orderId) {
+        // 2. 총 금액(totalPrice)과 수량(totalQuantity) 계산용 변수
+        int totalPrice = 0;
+        int totalQuantity = 0;
+        List<OrderItem> orderItems = new ArrayList<>();
+
+        // 3. 주문 상세 항목 생성
+        for (OrderCreateReq.OrderItemReq itemReq : req.orderItems()) {
+            Product product = productRepository.findById(itemReq.productId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
+
+            product.removeStock(itemReq.quantity()); // 재고 차감
+
+            orderItems.add(OrderItem.builder()
+                    .product(product)
+                    .quantity(itemReq.quantity())
+                    .build());
+
+            totalPrice += product.getPrice() * itemReq.quantity();
+            totalQuantity += itemReq.quantity();
+        }
+
+        // 4. 최종 주문 생성
+        Order order = Order.builder()
+                // .member(tempMember)
+                .orderBatch(orderBatch)
+                .address(req.address())
+                .zipCode(req.zipCode())
+                .orderedAt(LocalDateTime.now())
+                .totalPrice(totalPrice)
+                .totalQuantity(totalQuantity)
+                .orderItems(orderItems) // CascadeType.ALL을 위해 추가
+                .build();
+
+        // 5. 양방향 관계 설정 (OrderItem에 Order 주입)
+        for (OrderItem item : orderItems) {
+        }
+
+        return orderRepository.save(order).getId();
     }
 }

--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/order/service/OrderService.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/order/service/OrderService.java
@@ -55,18 +55,18 @@ public class OrderService {
 
         // 4. 최종 주문 생성
         Order order = Order.builder()
-                // .member(tempMember)
                 .orderBatch(orderBatch)
                 .address(req.address())
                 .zipCode(req.zipCode())
                 .orderedAt(LocalDateTime.now())
                 .totalPrice(totalPrice)
                 .totalQuantity(totalQuantity)
-                .orderItems(orderItems) // CascadeType.ALL을 위해 추가
+                .orderItems(orderItems)
                 .build();
 
         // 5. 양방향 관계 설정 (OrderItem에 Order 주입)
         for (OrderItem item : orderItems) {
+            item.assignOrder(order);
         }
 
         return orderRepository.save(order).getId();

--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/order/service/OrderService.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/order/service/OrderService.java
@@ -1,0 +1,26 @@
+package com.gridsandcircles.gc_coffee.order.service;
+
+import com.gridsandcircles.gc_coffee.order.repository.OrderRepository;
+import com.gridsandcircles.gc_coffee.product.repository.ProductRepository;
+import com.gridsandcircles.gc_coffee.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final ProductRepository productRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public Long createOrder() {
+        return null;
+    }
+
+    public void getOrderDetails(Long orderId) {
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
> PR과 연관된 이슈 번호를 작성해주세요.  
> PR 머지 시 이슈를 닫으려면 `Closes #번호` 형식으로 작성해주세요. ex) `Closes #2`

Closes #27 

## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.
- [x] 주문 생성 요청 DTO (`OrderCreateRequest`) 설계
- [x] 리포지토리 파일 생성 (`OrderRepository`)
- [x] 주문 생성 비즈니스 로직 구현 (`OrderService`)
- [x] 주문 생성 컨트롤러 엔드포인트 구현 (`POST /api/v1/orders`)


## 🎯 리뷰 포인트
> 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요.
- 리뷰 포인트
- `OrderService`에서 `totalPrice`와 `totalQuantity`를 계산하는 로직이 적절한지 봐주세요.
- `Product` 엔티티의 `removeStock`을 활용해 재고 차감을 처리했습니다.
- 현재 `Member` 관련 로직은 재원님의 구현 전이라 주석 처리되어 있습니다.

## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?