### PR TITLE
feat: 주문 시점 기준 배송 배치(OrderBatch) 자동 할당 로직 구현 (#38)

### DIFF
--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/order/service/OrderService.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/order/service/OrderService.java
@@ -24,26 +24,28 @@ public class OrderService {
 
     private final OrderRepository orderRepository;
     private final ProductRepository productRepository;
-//    private final MemberRepository memberRepository;
-    private final OrderBatchRepository orderBatchRepository;
+    private final OrderBatchService orderBatchService;
 
     @Transactional
     public Long createOrder(OrderCreateRequest req) {
-        // 1. 배송 회차 조회
-        OrderBatch orderBatch = orderBatchRepository.findById(1L)
-                .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_BATCH_NOT_FOUND));
+        // 1. 주문 시점 확정
+        LocalDateTime orderedAt = LocalDateTime.now();
 
-        // 2. 총 금액(totalPrice)과 수량(totalQuantity) 계산용 변수
+        // 2. 배송 배치 자동 결정
+        // 임시 Order 객체를 만들어 BatchService에 넘겨 배치를 결정
+        Order tempOrder = Order.builder().orderedAt(orderedAt).build();
+        OrderBatch orderBatch = orderBatchService.findOrCreateByOrder(tempOrder);
+
         int totalPrice = 0;
         int totalQuantity = 0;
         List<OrderItem> orderItems = new ArrayList<>();
 
-        // 3. 주문 상세 항목 생성
+        // 3. 주문 상세 항목 생성 및 재고 차감
         for (OrderCreateRequest.OrderItemReq itemReq : req.orderItems()) {
             Product product = productRepository.findById(itemReq.productId())
                     .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
 
-            product.removeStock(itemReq.quantity()); // 재고 차감
+            product.removeStock(itemReq.quantity());
 
             orderItems.add(OrderItem.builder()
                     .product(product)
@@ -56,18 +58,19 @@ public class OrderService {
 
         // 4. 최종 주문 생성
         Order order = Order.builder()
-                .orderBatch(orderBatch)
+                .orderBatch(orderBatch) // 자동으로 찾은 배치 주입
                 .address(req.address())
                 .zipCode(req.zipCode())
-                .orderedAt(LocalDateTime.now())
+                .orderedAt(orderedAt)
                 .totalPrice(totalPrice)
                 .totalQuantity(totalQuantity)
-                .orderItems(orderItems)
+                .orderItems(new ArrayList<>())
                 .build();
 
-        // 5. 양방향 관계 설정 (OrderItem에 Order 주입)
+        // 5. 양방향 관계 설정
         for (OrderItem item : orderItems) {
             item.assignOrder(order);
+            order.getOrderItems().add(item);
         }
 
         return orderRepository.save(order).getId();

--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/order/service/OrderService.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/order/service/OrderService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.ArrayList;
 
@@ -29,7 +30,7 @@ public class OrderService {
     @Transactional
     public Long createOrder(OrderCreateRequest req) {
         // 1. 주문 시점 확정
-        LocalDateTime orderedAt = LocalDateTime.now();
+        LocalDateTime orderedAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
 
         // 2. 배송 배치 자동 결정
         // 임시 Order 객체를 만들어 BatchService에 넘겨 배치를 결정


### PR DESCRIPTION
## 📌 관련 이슈
> PR과 연관된 이슈 번호를 작성해주세요.  
> PR 머지 시 이슈를 닫으려면 `Closes #번호` 형식으로 작성해주세요. ex) `Closes #2`

Closes #38

## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.
- [x] 배송 배치 자동 할당 로직 구현: OrderBatchService를 연동하여 주문 시각(orderedAt)이 14시 이전이면 당일, 14시 이후면 익일 배치를 자동 지정하도록 구현했습니다.
- [x] 서버 타임존(UTC)과 관계없이 정확한 배치를 판별하기 위해 주문 시각을 Asia/Seoul로 고정했습니다.

## 🎯 리뷰 포인트
> 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요.
- 타임존 처리: LocalDateTime.now(ZoneId.of("Asia/Seoul"))를 통해 KST 기준으로 배치가 정확히 갈리는지 봐주세요.
- OrderService에서 OrderBatchService를 주입받아 배치를 결정하는 흐름이 적절한지 확인 부탁드립니다.
- 만약 특정 날짜의 배치가 DB에 없을 때, findOrCreateByBatchDate가 정상적으로 새 배치를 생성하는지 로직을 검토해 주세요.

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
<img width="988" height="135" alt="image" src="https://github.com/user-attachments/assets/c09f4ce2-d5e6-40f0-9f69-c862692ba67f" />
<img width="455" height="111" alt="image" src="https://github.com/user-attachments/assets/c2023aae-7361-4d4b-af05-53cc73938155" />

24일 배치로 잘 들어옵니다.

## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?