### PR TITLE
feat: 관리자 상품 삭제 API 구현 및 예외 처리 (#46)

### DIFF
--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/product/controller/AdminProductController.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/product/controller/AdminProductController.java
@@ -31,4 +31,12 @@ public class AdminProductController {
         AdminProductUpdateResponse response = productService.updateProduct(productId, request);
         return ResponseEntity.ok(response);
     }
+
+    @DeleteMapping("/{productId}")
+    public ResponseEntity<Void> deleteProduct(@PathVariable Long productId) {
+        productService.deleteProduct(productId);
+
+        // 삭제 성공 시 응답 바디 없이 204 No Content 반환
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/product/service/ProductService.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/product/service/ProductService.java
@@ -37,4 +37,12 @@ public class ProductService {
 
         return AdminProductUpdateResponse.from(product);
     }
+
+    @Transactional
+    public void deleteProduct(Long productId) {
+        Product product = productRepository.findById(productId)
+                                           .orElseThrow(() -> new IllegalArgumentException("해당 상품을 찾을 수 없습니다. ID: " + productId));
+
+        productRepository.delete(product);
+    }
 }

--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/product/service/ProductService.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/product/service/ProductService.java
@@ -1,6 +1,8 @@
 package com.gridsandcircles.gc_coffee.product.service;
 
 import com.gridsandcircles.gc_coffee.entity.Product;
+import com.gridsandcircles.gc_coffee.global.exception.BusinessException;
+import com.gridsandcircles.gc_coffee.global.exception.ErrorCode;
 import com.gridsandcircles.gc_coffee.product.dto.AdminProductUpdateRequest;
 import com.gridsandcircles.gc_coffee.product.dto.AdminProductUpdateResponse;
 import com.gridsandcircles.gc_coffee.product.dto.ProductCreateRequest;
@@ -41,7 +43,7 @@ public class ProductService {
     @Transactional
     public void deleteProduct(Long productId) {
         Product product = productRepository.findById(productId)
-                                           .orElseThrow(() -> new IllegalArgumentException("해당 상품을 찾을 수 없습니다. ID: " + productId));
+                                           .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
 
         productRepository.delete(product);
     }


### PR DESCRIPTION
## 📌 관련 이슈
Closes #46 

## 🛠️ 작업 내용
- [x] 상품 삭제 API 구현
DELETE /api/v1/admin/products/{productId} 엔드포인트 추가
- [x] 비즈니스 로직 적용: ProductService에서 Hard Delete 구현
- [x] 예외 처리: 존재하지 않는 ID로 삭제 시도 시 'INTERNAL_ERROR'가 발생하던 문제 해결


## 🎯 리뷰 포인트
- 응답 상태 코드: 삭제 성공 시  '204 No Content' 반환하도록 설정했습니다. 

- 중복 삭제: 이미 삭제된 상품을 다시 삭제하려고 할 때, 서버 오류가(500) 아닌 정의된 에러(PRODUCT_NOT_FOUND)와 함께 '404'  상태 코드가 정상적으로 반환되는지 확인 부탁드립니다. 


## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?