### PR TITLE
feat: 고객 조회 및 생성 API 구현 (#49)

### DIFF
--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/member/controller/MemberController.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/member/controller/MemberController.java
@@ -1,0 +1,29 @@
+package com.gridsandcircles.gc_coffee.member.controller;
+
+import com.gridsandcircles.gc_coffee.global.dto.ApiResponse;
+import com.gridsandcircles.gc_coffee.member.dto.MemberRequest;
+import com.gridsandcircles.gc_coffee.member.dto.MemberResponse;
+import com.gridsandcircles.gc_coffee.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberservice;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<MemberResponse>> createOrFindMember(
+            @RequestBody MemberRequest request){
+        MemberResponse response = memberservice.findOrCreateMember(request);
+
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+}

--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/member/dto/MemberRequest.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/member/dto/MemberRequest.java
@@ -1,0 +1,6 @@
+package com.gridsandcircles.gc_coffee.member.dto;
+
+public record MemberRequest(
+        String email
+) {
+}

--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/member/dto/MemberResponse.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/member/dto/MemberResponse.java
@@ -1,0 +1,18 @@
+package com.gridsandcircles.gc_coffee.member.dto;
+
+import com.gridsandcircles.gc_coffee.entity.Member;
+import com.gridsandcircles.gc_coffee.entity.Role;
+
+public record MemberResponse(
+        Long id,
+        String email,
+        Role role
+) {
+    public static MemberResponse from(Member member) {
+        return new MemberResponse(
+                member.getId(),
+                member.getEmail(),
+                member.getRole()
+        );
+    }
+}

--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/member/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.gridsandcircles.gc_coffee.member.repository;
+
+import com.gridsandcircles.gc_coffee.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long>{
+    Optional<Member> findByEmail(String email);
+}

--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/member/service/MemberService.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/member/service/MemberService.java
@@ -1,0 +1,26 @@
+package com.gridsandcircles.gc_coffee.member.service;
+
+import com.gridsandcircles.gc_coffee.entity.Member;
+import com.gridsandcircles.gc_coffee.member.dto.MemberRequest;
+import com.gridsandcircles.gc_coffee.member.dto.MemberResponse;
+import com.gridsandcircles.gc_coffee.member.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public MemberResponse findOrCreateMember(MemberRequest request){
+
+        // 이메일로 기존 회원 조회, 없으면 새로운 Member 객체 생성 후 DB 저장
+        Member member = memberRepository.findByEmail(request.email())
+                                        .orElseGet(()->memberRepository.save(new Member(request.email())));
+
+        return MemberResponse.from(member);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
Closes #49 

## 🛠️ 작업 내용
- [x] **DTO**: 
MemberRequest(email)와 MemberResponse(id, email, role)를 record로 구현하여 데이터 전달

- [x] **Repository**: 
MemberRepository에 이메일 기반 조회를 위한 findByEmail 쿼리 메서드 추가

- [x] **비즈니스 로직**: 
존재 시 조회, 미존재 시 생성하는 findOrCreate 로직 구현

- [x] ApiResponse.ok() 적용하여 일관된 응답 포맷 유지


## 🎯 리뷰 포인트
- 멱등성 확인: 동일한 이메일로 여러 번 요청 시 최초 1회만 insert, 이후에는 select만 수행되는 것 로그로 확인했습니다.
- 보안: 응답 DTO에서 비밀번호 필드 제외하여 정보 노출 위험 방지했습니다.


## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
포스트맨 결과: 
<img width="329" height="153" alt="image" src="https://github.com/user-attachments/assets/a901917b-9573-4f19-a94e-3d86dc1a9568" />

## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?