### PR TITLE
feat: 관리자 페이지 공통 레이아웃 및 상품 관리 UI 구현 (#54)

### DIFF
--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -1,0 +1,41 @@
+import Link from 'next/link';
+import React from 'react';
+
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+    return (
+        <div className="flex h-screen bg-gray-100 font-sans">
+            {/* ⬅️ 좌측 사이드바 */}
+            <aside className="w-64 bg-gray-900 text-white flex flex-col shadow-xl">
+                <div className="p-6 border-b border-gray-800">
+                    <h1 className="text-2xl font-bold tracking-wider">GC Admin</h1>
+                    <p className="text-sm text-gray-400 mt-1">Grids & Circles</p>
+                </div>
+
+                <nav className="flex-1 px-4 py-6 space-y-2">
+                    <Link href="/admin/products" className="block px-4 py-3 rounded-lg hover:bg-gray-800 transition-colors text-gray-300 hover:text-white font-medium">
+                        📦 상품 관리
+                    </Link>
+                    <Link href="/admin/orders" className="block px-4 py-3 rounded-lg hover:bg-gray-800 transition-colors text-gray-300 hover:text-white font-medium">
+                        🛒 주문 관리
+                    </Link>
+                </nav>
+            </aside>
+
+            {/* ➡️ 우측 메인 콘텐츠 영역 */}
+            <main className="flex-1 flex flex-col overflow-hidden">
+                {/* 상단 헤더바 */}
+                <header className="bg-white shadow-sm h-16 flex items-center justify-between px-8 border-b border-gray-200">
+                    <h2 className="text-xl font-semibold text-gray-800">관리자 대시보드</h2>
+                    <button className="text-sm px-4 py-2 bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200 transition font-medium">
+                        로그아웃
+                    </button>
+                </header>
+
+                {/* 실제 내용이 바뀌는 알맹이 영역 */}
+                <div className="flex-1 overflow-y-auto p-8">
+                    {children}
+                </div>
+            </main>
+        </div>
+    );
+}

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -3,37 +3,34 @@ import React from 'react';
 
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
     return (
-        <div className="flex h-screen bg-gray-100 font-sans">
+        <div className="flex h-screen bg-[#f8f9fa] font-sans">
             {/* 좌측 사이드바 */}
-            <aside className="w-64 bg-gray-900 text-white flex flex-col shadow-xl">
-                <div className="p-6 border-b border-gray-800">
-                    <h1 className="text-2xl font-bold tracking-wider">GC Admin</h1>
-                    <p className="text-sm text-gray-400 mt-1">Grids & Circles</p>
+            <aside className="w-64 bg-[#222222] text-white flex flex-col shadow-2xl">
+                <div className="p-8 border-b border-white/10">
+                    <h1 className="text-2xl font-black tracking-tight text-[#ba9470]">GC Admin</h1>
+                    <p className="text-[10px] text-gray-500 mt-1 uppercase tracking-[0.2em]">Coffee Management</p>
                 </div>
 
-                <nav className="flex-1 px-4 py-6 space-y-2">
-                    <Link href="/admin/products" className="block px-4 py-3 rounded-lg hover:bg-gray-800 transition-colors text-gray-300 hover:text-white font-medium">
-                        📦 상품 관리
+                <nav className="flex-1 px-4 py-8 space-y-1">
+                    <Link href="/admin/products" className="flex items-center px-4 py-3 rounded-lg hover:bg-white/5 transition-all text-gray-400 hover:text-[#ba9470] group">
+                        <span className="mr-3 text-lg opacity-70 group-hover:opacity-100">📦</span>
+                        <span className="font-medium">상품 관리</span>
                     </Link>
-                    <Link href="/admin/orders" className="block px-4 py-3 rounded-lg hover:bg-gray-800 transition-colors text-gray-300 hover:text-white font-medium">
-                        🛒 주문 관리
+                    <Link href="/admin/orders" className="flex items-center px-4 py-3 rounded-lg hover:bg-white/5 transition-all text-gray-400 hover:text-[#ba9470] group">
+                        <span className="mr-3 text-lg opacity-70 group-hover:opacity-100">🛒</span>
+                        <span className="font-medium">주문 관리</span>
                     </Link>
                 </nav>
             </aside>
 
-            {/* 우측 메인 콘텐츠 영역 */}
+            {/* 우측 영역 */}
             <main className="flex-1 flex flex-col overflow-hidden">
-                {/* 상단 헤더바 */}
-                <header className="bg-white shadow-sm h-16 flex items-center justify-between px-8 border-b border-gray-200">
-                    <h2 className="text-xl font-semibold text-gray-800">관리자 대시보드</h2>
-                    <button className="text-sm px-4 py-2 bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200 transition font-medium">
-                        로그아웃
-                    </button>
+                <header className="bg-white h-20 flex items-center justify-between px-10 border-b border-gray-200">
+                    <h2 className="text-xl font-bold text-[#222222]">관리자 대시보드</h2>
+                    <button className="text-sm font-bold text-[#ba9470] hover:underline">로그아웃</button>
                 </header>
-
-                {/* 실제 내용이 바뀌는 영역 */}
-                <div className="flex-1 overflow-y-auto p-8">
-                    {children}
+                <div className="flex-1 overflow-y-auto p-10 bg-white">
+                    <div className="max-w-6xl mx-auto">{children}</div>
                 </div>
             </main>
         </div>

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -1,23 +1,51 @@
+'use client';
+
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import React from 'react';
 
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
+    const pathname = usePathname();
+
+    const isActive = (href: string) => pathname.startsWith(href);
+
     return (
         <div className="flex h-screen bg-[#f8f9fa] font-sans">
-            {/* 좌측 사이드바 */}
             <aside className="w-64 bg-[#222222] text-white flex flex-col shadow-2xl">
                 <div className="p-8 border-b border-white/10">
                     <h1 className="text-2xl font-black tracking-tight text-[#ba9470]">GC Admin</h1>
-                    <p className="text-[10px] text-gray-500 mt-1 uppercase tracking-[0.2em]">Coffee Management</p>
+                    <p className="text-[10px] text-gray-500 mt-1 uppercase tracking-[0.2em]">Management System</p>
                 </div>
 
-                <nav className="flex-1 px-4 py-8 space-y-1">
-                    <Link href="/admin/products" className="flex items-center px-4 py-3 rounded-lg hover:bg-white/5 transition-all text-gray-400 hover:text-[#ba9470] group">
-                        <span className="mr-3 text-lg opacity-70 group-hover:opacity-100">📦</span>
+                <nav className="flex-1 px-4 py-8 space-y-2">
+                    {/* 상품 관리 메뉴 */}
+                    <Link
+                        href="/admin/products"
+                        className={`flex items-center px-4 py-3 rounded-lg transition-all group relative ${isActive('/admin/products')
+                            ? 'bg-white/10 text-[#ba9470]' // 활성화 시 배경/글자색
+                            : 'text-gray-400 hover:text-white hover:bg-white/5' // 비활성화 시
+                            }`}
+                    >
+                        {/* 활성화 시 왼쪽에 나타나는 세로 바 */}
+                        {isActive('/admin/products') && (
+                            <div className="absolute left-0 w-1 h-6 bg-[#ba9470] rounded-r-full" />
+                        )}
+                        <span className={`mr-3 text-lg ${isActive('/admin/products') ? 'opacity-100' : 'opacity-70'}`}>📦</span>
                         <span className="font-medium">상품 관리</span>
                     </Link>
-                    <Link href="/admin/orders" className="flex items-center px-4 py-3 rounded-lg hover:bg-white/5 transition-all text-gray-400 hover:text-[#ba9470] group">
-                        <span className="mr-3 text-lg opacity-70 group-hover:opacity-100">🛒</span>
+
+                    {/* 주문 관리 메뉴 */}
+                    <Link
+                        href="/admin/orders"
+                        className={`flex items-center px-4 py-3 rounded-lg transition-all group relative ${isActive('/admin/orders')
+                            ? 'bg-white/10 text-[#ba9470]'
+                            : 'text-gray-400 hover:text-white hover:bg-white/5'
+                            }`}
+                    >
+                        {isActive('/admin/orders') && (
+                            <div className="absolute left-0 w-1 h-6 bg-[#ba9470] rounded-r-full" />
+                        )}
+                        <span className={`mr-3 text-lg ${isActive('/admin/orders') ? 'opacity-100' : 'opacity-70'}`}>🛒</span>
                         <span className="font-medium">주문 관리</span>
                     </Link>
                 </nav>
@@ -26,7 +54,9 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
             {/* 우측 영역 */}
             <main className="flex-1 flex flex-col overflow-hidden">
                 <header className="bg-white h-20 flex items-center justify-between px-10 border-b border-gray-200">
-                    <h2 className="text-xl font-bold text-[#222222]">관리자 대시보드</h2>
+                    <h2 className="text-xl font-bold text-[#222222]">
+                        {isActive('/admin/products') ? '📦 상품 관리' : '🛒 주문 관리'}
+                    </h2>
                     <button className="text-sm font-bold text-[#ba9470] hover:underline">로그아웃</button>
                 </header>
                 <div className="flex-1 overflow-y-auto p-10 bg-white">

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
     return (
         <div className="flex h-screen bg-gray-100 font-sans">
-            {/* ⬅️ 좌측 사이드바 */}
+            {/* 좌측 사이드바 */}
             <aside className="w-64 bg-gray-900 text-white flex flex-col shadow-xl">
                 <div className="p-6 border-b border-gray-800">
                     <h1 className="text-2xl font-bold tracking-wider">GC Admin</h1>
@@ -21,7 +21,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
                 </nav>
             </aside>
 
-            {/* ➡️ 우측 메인 콘텐츠 영역 */}
+            {/* 우측 메인 콘텐츠 영역 */}
             <main className="flex-1 flex flex-col overflow-hidden">
                 {/* 상단 헤더바 */}
                 <header className="bg-white shadow-sm h-16 flex items-center justify-between px-8 border-b border-gray-200">
@@ -31,7 +31,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
                     </button>
                 </header>
 
-                {/* 실제 내용이 바뀌는 알맹이 영역 */}
+                {/* 실제 내용이 바뀌는 영역 */}
                 <div className="flex-1 overflow-y-auto p-8">
                     {children}
                 </div>

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function AdminPage() {
+    redirect("/admin/products");
+}

--- a/frontend/src/app/admin/products/page.tsx
+++ b/frontend/src/app/admin/products/page.tsx
@@ -15,7 +15,7 @@ export default function AdminProductsPage() {
           <h2 className="text-3xl font-black text-gray-900">상품 관리</h2>
           <p className="text-gray-500 mt-1">판매 중인 원두 상품을 등록하고 수정할 수 있습니다.</p>
         </div>
-        <button className="bg-indigo-600 text-white px-6 py-3 rounded-xl hover:bg-indigo-700 shadow-lg shadow-indigo-200 transition-all font-bold">
+        <button className="bg-[#ba9470] text-white px-6 py-3 rounded-lg hover:bg-[#a67c52] shadow-md transition-all font-bold">
           + 새 상품 등록
         </button>
       </div>
@@ -39,18 +39,18 @@ export default function AdminProductsPage() {
                 <td className="px-8 py-5 whitespace-nowrap text-sm text-gray-600">{product.price.toLocaleString()}원</td>
                 <td className="px-8 py-5 whitespace-nowrap">
                   {product.stock > 0 ? (
-                    <span className="px-3 py-1 text-xs font-bold bg-green-100 text-green-700 rounded-full">
+                    <span className="px-3 py-1 text-xs font-bold bg-[#ba9470]/10 text-[#ba9470] rounded-md">
                       재고 있음 ({product.stock})
                     </span>
                   ) : (
-                    <span className="px-3 py-1 text-xs font-bold bg-red-100 text-red-700 rounded-full">
+                    <span className="px-3 py-1 text-xs font-bold bg-gray-100 text-gray-400 rounded-md">
                       품절
                     </span>
                   )}
                 </td>
-                <td className="px-8 py-5 whitespace-nowrap text-sm font-bold space-x-4">
-                  <button className="text-indigo-600 hover:text-indigo-900 transition-colors">수정</button>
-                  <button className="text-rose-600 hover:text-rose-900 transition-colors">삭제</button>
+                <td className="px-8 py-5 whitespace-nowrap text-sm font-bold space-x-4 text-center">
+                  <button className="text-[#ba9470] hover:text-[#a67c52] transition-colors">수정</button>
+                  <button className="text-gray-400 hover:text-red-500 transition-colors">삭제</button>
                 </td>
               </tr>
             ))}

--- a/frontend/src/app/admin/products/page.tsx
+++ b/frontend/src/app/admin/products/page.tsx
@@ -1,3 +1,62 @@
+'use client';
+
 export default function AdminProductsPage() {
-    return <div>관리자 상품 관리 페이지</div>;
-  }
+  // 백엔드 API 연동 전 테스트를 위한 더미 데이터
+  const dummyProducts = [
+    { id: 1, name: '콜롬비아 수프리모 원두', price: 15000, stock: 50 },
+    { id: 2, name: '에티오피아 예가체프 원두', price: 18000, stock: 12 },
+    { id: 3, name: '인도네시아 만델링 원두', price: 16500, stock: 0 },
+  ];
+
+  return (
+    <div className="space-y-8">
+      <div className="flex justify-between items-end">
+        <div>
+          <h2 className="text-3xl font-black text-gray-900">상품 관리</h2>
+          <p className="text-gray-500 mt-1">판매 중인 원두 상품을 등록하고 수정할 수 있습니다.</p>
+        </div>
+        <button className="bg-indigo-600 text-white px-6 py-3 rounded-xl hover:bg-indigo-700 shadow-lg shadow-indigo-200 transition-all font-bold">
+          + 새 상품 등록
+        </button>
+      </div>
+
+      <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              {['ID', '상품명', '가격', '재고 상태', '관리'].map((header) => (
+                <th key={header} className="px-8 py-5 text-left text-xs font-bold text-gray-400 uppercase tracking-widest">
+                  {header}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-100">
+            {dummyProducts.map((product) => (
+              <tr key={product.id} className="hover:bg-indigo-50/30 transition-colors">
+                <td className="px-8 py-5 whitespace-nowrap text-sm text-gray-500 font-medium">#{product.id}</td>
+                <td className="px-8 py-5 whitespace-nowrap text-sm font-bold text-gray-900">{product.name}</td>
+                <td className="px-8 py-5 whitespace-nowrap text-sm text-gray-600">{product.price.toLocaleString()}원</td>
+                <td className="px-8 py-5 whitespace-nowrap">
+                  {product.stock > 0 ? (
+                    <span className="px-3 py-1 text-xs font-bold bg-green-100 text-green-700 rounded-full">
+                      재고 있음 ({product.stock})
+                    </span>
+                  ) : (
+                    <span className="px-3 py-1 text-xs font-bold bg-red-100 text-red-700 rounded-full">
+                      품절
+                    </span>
+                  )}
+                </td>
+                <td className="px-8 py-5 whitespace-nowrap text-sm font-bold space-x-4">
+                  <button className="text-indigo-600 hover:text-indigo-900 transition-colors">수정</button>
+                  <button className="text-rose-600 hover:text-rose-900 transition-colors">삭제</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 📌 관련 이슈
Closes #54 

## 🛠️ 작업 내용
- **공통 레이아웃** 
`/admin/layout.tsx`를 통해 모든 어드민 페이지에서 공유되는 사이드바와 헤더를 구축

- **리다이렉트** 
`/admin` 루트 경로 접속 시 `/admin/products`로 자동 리다이렉트되도록 설정

- **테이블 UI** 
Tailwind CSS를 사용하여 백엔드 상품 데이터 목록 조회 테이블을 구현

- `usePathname` 사용 실시간 URL 경로 감지
- 활성화된 메뉴에 컬러 및 배경 하이라이트 적용 
- 메뉴 좌측 인디케이터 바 추가
- 현재 경로에 따라 상단 헤더 타이틀 동적으로 변경

## 🎯 리뷰 포인트
- 와이어프레임이 존재하지 않아 표준적인 대시보드 UI를 적용했습니다. 보시기에 사이드바 구성이나 톤앤매너가 적절한지 의견 부탁드립니다. 
- 현재는 더미 데이터 사용중으로, 추후 실제 API 연동 진행 예정입니다. 
- 디자인적으로 강조 효과가 너무 과하지 않은지, 조화로운지 확인 부탁드립니다.  


## 📸 스크린샷 
<img width="1323" height="589" alt="image" src="https://github.com/user-attachments/assets/e6f8c8c0-b3c2-443f-ac84-cb2d94b68063" />

## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?(`npm run dev`)