### PR TITLE
feat: 관리자 상품 등록 모달 UI 및 POST API 연동 (#76)

### DIFF
--- a/frontend/src/app/admin/products/page.tsx
+++ b/frontend/src/app/admin/products/page.tsx
@@ -4,28 +4,28 @@ import { useEffect, useState } from 'react';
 import { Product, ApiResponse } from '@/app/type/product';
 
 export default function AdminProductsPage() {
-  // 목록 조회용 
   const [products, setProducts] = useState<Product[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // 모달 및 폼 입력용 
+  // 모달 및 새 상품 입력 상태
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [newProduct, setNewProduct] = useState({ name: '', price: '', stock: '' });
 
-  // 상품 목록 불러오기
+  // 상품 목록 불러오기 
   const fetchProducts = async () => {
     try {
       setIsLoading(true);
-      const response = await fetch('http://localhost:8080/api/v1/products', {
-        cache: 'no-store'
+      const timestamp = new Date().getTime();
+      // size=100으로 백엔드의 4개 제한을 우회하고, t파라미터로 캐시 방지
+      const response = await fetch(`http://localhost:8080/api/v1/products?size=100&t=${timestamp}`, {
+        cache: 'no-store',
       });
 
       if (!response.ok) throw new Error('서버 응답에 문제가 발생했습니다.');
 
       const result = await response.json();
 
-      // 데이터 로직(일반/페이징 응답 모두 대응)
       let productList = [];
       if (Array.isArray(result)) {
         productList = result;
@@ -44,21 +44,34 @@ export default function AdminProductsPage() {
     }
   };
 
-  // 컴포넌트 마운트 시 최초 1회 실행
   useEffect(() => {
     fetchProducts();
   }, []);
 
-  // 새 상품 등록 (POST)
+  // 모달 닫기 및 폼 초기화
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+    setNewProduct({ name: '', price: '', stock: '' });
+  };
+
+  // 상품 등록 제출
   const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault(); // 폼 제출 시 새로고침 방지
+    e.preventDefault();
+
+    const trimmedName = newProduct.name.trim();
+
+    // 유효성 검사: 숫자로만 된 이름 방지
+    if (/^\d+$/.test(trimmedName)) {
+      alert('상품명은 숫자로만 입력할 수 없습니다. 정확한 이름을 입력해주세요.');
+      return;
+    }
 
     try {
       const response = await fetch('http://localhost:8080/api/v1/admin/products', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          name: newProduct.name,
+          name: trimmedName,
           price: Number(newProduct.price),
           stock: Number(newProduct.stock)
         }),
@@ -66,9 +79,8 @@ export default function AdminProductsPage() {
 
       if (response.ok) {
         alert('상품이 성공적으로 등록되었습니다!');
-        setIsModalOpen(false);
-        setNewProduct({ name: '', price: '', stock: '' });
-        fetchProducts(); // 목록 최신화
+        handleCloseModal(); // 닫으면서 초기화
+        fetchProducts();    // 목록 최신화
       } else {
         alert('상품 등록에 실패했습니다.');
       }
@@ -78,7 +90,6 @@ export default function AdminProductsPage() {
     }
   };
 
-  // 로딩 중 UI
   if (isLoading && products.length === 0) {
     return (
       <div className="flex justify-center items-center h-64">
@@ -87,15 +98,10 @@ export default function AdminProductsPage() {
     );
   }
 
-  // 에러 UI
-  if (error) {
-    return <div className="bg-red-50 p-6 rounded-xl border border-red-100 text-red-600 font-medium">⚠️ {error}</div>;
-  }
+  if (error) return <div className="bg-red-50 p-6 rounded-xl border border-red-100 text-red-600 font-medium">⚠️ {error}</div>;
 
-  // 메인 UI
   return (
     <div className="space-y-8 relative">
-      {/* 상단 타이틀 및 등록 버튼 */}
       <div className="flex justify-between items-end">
         <div>
           <h2 className="text-3xl font-black text-[#222222]">상품 관리</h2>
@@ -109,7 +115,6 @@ export default function AdminProductsPage() {
         </button>
       </div>
 
-      {/* 실데이터 렌더링 테이블 */}
       <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden">
         <table className="min-w-full divide-y divide-gray-200">
           <thead className="bg-gray-50">
@@ -125,30 +130,32 @@ export default function AdminProductsPage() {
             {products.length === 0 ? (
               <tr><td colSpan={5} className="px-8 py-10 text-center text-gray-400 font-medium">등록된 상품이 없습니다.</td></tr>
             ) : (
-              products.map((product) => (
-                <tr key={product.id || product.id} className="hover:bg-[#ba9470]/5 transition-colors">
-                  <td className="px-8 py-5 whitespace-nowrap text-sm text-gray-500 font-medium">#{product.id || product.id}</td>
-                  <td className="px-8 py-5 whitespace-nowrap text-sm font-bold text-[#222222]">{product.name}</td>
-                  <td className="px-8 py-5 whitespace-nowrap text-sm text-gray-600">{product.price.toLocaleString()}원</td>
-                  <td className="px-8 py-5 whitespace-nowrap">
-                    {product.stock > 0 ? (
-                      <span className="px-3 py-1 text-xs font-bold bg-[#ba9470]/10 text-[#ba9470] rounded-md">재고 있음 ({product.stock})</span>
-                    ) : (
-                      <span className="px-3 py-1 text-xs font-bold bg-gray-100 text-gray-400 rounded-md">품절</span>
-                    )}
-                  </td>
-                  <td className="px-8 py-5 whitespace-nowrap text-sm font-bold space-x-6 text-center">
-                    <button className="text-[#ba9470] hover:text-[#a67c52] transition-colors">수정</button>
-                    <button className="text-gray-300 hover:text-red-500 transition-colors">삭제</button>
-                  </td>
-                </tr>
-              ))
+              products.map((product) => {
+                const pId = product.id || (product as any).id;
+                return (
+                  <tr key={pId} className="hover:bg-[#ba9470]/5 transition-colors">
+                    <td className="px-8 py-5 whitespace-nowrap text-sm text-gray-500 font-medium">#{pId}</td>
+                    <td className="px-8 py-5 whitespace-nowrap text-sm font-bold text-[#222222]">{product.name}</td>
+                    <td className="px-8 py-5 whitespace-nowrap text-sm text-gray-600">{product.price.toLocaleString()}원</td>
+                    <td className="px-8 py-5 whitespace-nowrap">
+                      {product.stock > 0 ? (
+                        <span className="px-3 py-1 text-xs font-bold bg-[#ba9470]/10 text-[#ba9470] rounded-md">재고 있음 ({product.stock})</span>
+                      ) : (
+                        <span className="px-3 py-1 text-xs font-bold bg-gray-100 text-gray-400 rounded-md">품절</span>
+                      )}
+                    </td>
+                    <td className="px-8 py-5 whitespace-nowrap text-sm font-bold space-x-6 text-center">
+                      <button className="text-gray-300 cursor-not-allowed" disabled title="추후 구현 예정">수정</button>
+                      <button className="text-gray-300 cursor-not-allowed" disabled title="추후 구현 예정">삭제</button>
+                    </td>
+                  </tr>
+                );
+              })
             )}
           </tbody>
         </table>
       </div>
 
-      {/* 상품 등록 모달 (isModalOpen이 true일 때만 렌더링) */}
       {isModalOpen && (
         <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 animate-fadeIn">
           <div className="bg-white p-8 rounded-2xl w-[400px] shadow-2xl">
@@ -158,7 +165,7 @@ export default function AdminProductsPage() {
                 <label className="block text-sm font-bold text-gray-700 mb-2">상품명</label>
                 <input
                   type="text" required placeholder="예: 콜롬비아 수프리모"
-                  className="w-full border border-gray-200 rounded-lg p-3 bg-gray-50 focus:bg-white focus:ring-2 focus:ring-[#ba9470] focus:border-transparent outline-none transition-all"
+                  className="w-full border border-gray-200 rounded-lg p-3 bg-gray-50 focus:bg-white focus:ring-2 focus:ring-[#ba9470] outline-none transition-all"
                   value={newProduct.name}
                   onChange={(e) => setNewProduct({ ...newProduct, name: e.target.value })}
                 />
@@ -168,16 +175,16 @@ export default function AdminProductsPage() {
                   <label className="block text-sm font-bold text-gray-700 mb-2">가격 (원)</label>
                   <input
                     type="number" required placeholder="0" min="0"
-                    className="w-full border border-gray-200 rounded-lg p-3 bg-gray-50 focus:bg-white focus:ring-2 focus:ring-[#ba9470] focus:border-transparent outline-none transition-all"
+                    className="w-full border border-gray-200 rounded-lg p-3 bg-gray-50 focus:bg-white focus:ring-2 focus:ring-[#ba9470] outline-none transition-all"
                     value={newProduct.price}
                     onChange={(e) => setNewProduct({ ...newProduct, price: e.target.value })}
                   />
                 </div>
                 <div>
-                  <label className="block text-sm font-bold text-gray-700 mb-2">초기 재고 (개)</label>
+                  <label className="block text-sm font-bold text-gray-700 mb-2">재고 (개)</label>
                   <input
                     type="number" required placeholder="0" min="0"
-                    className="w-full border border-gray-200 rounded-lg p-3 bg-gray-50 focus:bg-white focus:ring-2 focus:ring-[#ba9470] focus:border-transparent outline-none transition-all"
+                    className="w-full border border-gray-200 rounded-lg p-3 bg-gray-50 focus:bg-white focus:ring-2 focus:ring-[#ba9470] outline-none transition-all"
                     value={newProduct.stock}
                     onChange={(e) => setNewProduct({ ...newProduct, stock: e.target.value })}
                   />
@@ -186,7 +193,7 @@ export default function AdminProductsPage() {
               <div className="flex space-x-3 pt-4">
                 <button
                   type="button"
-                  onClick={() => setIsModalOpen(false)} // 닫기버튼
+                  onClick={handleCloseModal}
                   className="flex-1 py-3 bg-gray-100 text-gray-600 rounded-lg font-bold hover:bg-gray-200 transition-colors"
                 >
                   취소

--- a/frontend/src/app/admin/products/page.tsx
+++ b/frontend/src/app/admin/products/page.tsx
@@ -4,57 +4,82 @@ import { useEffect, useState } from 'react';
 import { Product, ApiResponse } from '@/app/type/product';
 
 export default function AdminProductsPage() {
+  // 목록 조회용 
   const [products, setProducts] = useState<Product[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // 컴포넌트 마운트 시 데이터 가져오기
-  useEffect(() => {
-    const fetchProducts = async () => {
-      try {
-        setIsLoading(true);
-        const response = await fetch('http://localhost:8080/api/v1/products');
+  // 모달 및 폼 입력용 
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [newProduct, setNewProduct] = useState({ name: '', price: '', stock: '' });
 
-        if (!response.ok) {
-          throw new Error('네트워크 응답에 문제가 발생했습니다.');
-        }
+  // 상품 목록 불러오기
+  const fetchProducts = async () => {
+    try {
+      setIsLoading(true);
+      const response = await fetch('http://localhost:8080/api/v1/products', {
+        cache: 'no-store'
+      });
 
-        const result = await response.json();
+      if (!response.ok) throw new Error('서버 응답에 문제가 발생했습니다.');
 
-        // 백엔드가 배열을 보냈을 경우
-        if (Array.isArray(result)) {
-          setProducts(result);
-        }
-        // ApiResponse 형태로 보냈을 경우
-        else if (result.success !== undefined) {
-          if (result.success) {
-            // data가 배열인지, 아니면 페이징 content인지 체크
-            if (Array.isArray(result.data)) {
-              setProducts(result.data); // data가 배열이면 바로 삽입
-            } else if (result.data && Array.isArray(result.data.content)) {
-              setProducts(result.data.content); // data.content가 배열이면 삽입 (페이징 시)
-            } else {
-              setProducts([]); // 둘 다 아니면 에러 방지를 위해 빈 배열 삽입
-            }
-          } else {
-            setError(result.error?.message || '데이터를 불러오는데 실패했습니다.');
-          }
-        } else {
-          setProducts([]);
-        }
-      } catch (err) {
-        console.error('API 연동 에러:', err);
-        setError('백엔드 서버 연결을 확인해주세요.');
-      } finally {
-        setIsLoading(false);
+      const result = await response.json();
+
+      // 데이터 로직(일반/페이징 응답 모두 대응)
+      let productList = [];
+      if (Array.isArray(result)) {
+        productList = result;
+      } else if (result.data && Array.isArray(result.data)) {
+        productList = result.data;
+      } else if (result.data && Array.isArray(result.data.content)) {
+        productList = result.data.content;
       }
-    };
+      setProducts(productList);
 
+    } catch (err) {
+      console.error('API 연동 에러:', err);
+      setError('서버 연결을 확인해주세요.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 컴포넌트 마운트 시 최초 1회 실행
+  useEffect(() => {
     fetchProducts();
   }, []);
 
-  // 로딩 상태 UI
-  if (isLoading) {
+  // 새 상품 등록 (POST)
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault(); // 폼 제출 시 새로고침 방지
+
+    try {
+      const response = await fetch('http://localhost:8080/api/v1/admin/products', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: newProduct.name,
+          price: Number(newProduct.price),
+          stock: Number(newProduct.stock)
+        }),
+      });
+
+      if (response.ok) {
+        alert('상품이 성공적으로 등록되었습니다!');
+        setIsModalOpen(false);
+        setNewProduct({ name: '', price: '', stock: '' });
+        fetchProducts(); // 목록 최신화
+      } else {
+        alert('상품 등록에 실패했습니다.');
+      }
+    } catch (err) {
+      console.error('등록 에러:', err);
+      alert('서버와 통신 중 에러가 발생했습니다.');
+    }
+  };
+
+  // 로딩 중 UI
+  if (isLoading && products.length === 0) {
     return (
       <div className="flex justify-center items-center h-64">
         <div className="text-[#ba9470] font-bold animate-pulse">원두 정보를 가져오는 중...</div>
@@ -62,24 +87,24 @@ export default function AdminProductsPage() {
     );
   }
 
-  // 에러 발생 시 UI
+  // 에러 UI
   if (error) {
-    return (
-      <div className="bg-red-50 p-6 rounded-xl border border-red-100 text-red-600 font-medium">
-        ⚠️ {error}
-      </div>
-    );
+    return <div className="bg-red-50 p-6 rounded-xl border border-red-100 text-red-600 font-medium">⚠️ {error}</div>;
   }
 
+  // 메인 UI
   return (
-    <div className="space-y-8">
+    <div className="space-y-8 relative">
       {/* 상단 타이틀 및 등록 버튼 */}
       <div className="flex justify-between items-end">
         <div>
           <h2 className="text-3xl font-black text-[#222222]">상품 관리</h2>
           <p className="text-gray-500 mt-1 font-medium">판매 중인 원두 상품을 실시간으로 관리합니다.</p>
         </div>
-        <button className="bg-[#ba9470] text-white px-6 py-3 rounded-lg hover:bg-[#a67c52] shadow-md transition-all font-bold">
+        <button
+          onClick={() => setIsModalOpen(true)}
+          className="bg-[#ba9470] text-white px-6 py-3 rounded-lg hover:bg-[#a67c52] shadow-md transition-all font-bold"
+        >
           + 새 상품 등록
         </button>
       </div>
@@ -90,11 +115,7 @@ export default function AdminProductsPage() {
           <thead className="bg-gray-50">
             <tr>
               {['ID', '상품명', '가격', '재고 상태', '관리'].map((header) => (
-                <th
-                  key={header}
-                  className={`px-8 py-5 text-xs font-bold text-gray-400 uppercase tracking-widest ${header === '관리' ? 'text-center' : 'text-left'
-                    }`}
-                >
+                <th key={header} className={`px-8 py-5 text-xs font-bold text-gray-400 uppercase tracking-widest ${header === '관리' ? 'text-center' : 'text-left'}`}>
                   {header}
                 </th>
               ))}
@@ -102,26 +123,18 @@ export default function AdminProductsPage() {
           </thead>
           <tbody className="bg-white divide-y divide-gray-100">
             {products.length === 0 ? (
-              <tr>
-                <td colSpan={5} className="px-8 py-10 text-center text-gray-400 font-medium">
-                  등록된 상품이 없습니다.
-                </td>
-              </tr>
+              <tr><td colSpan={5} className="px-8 py-10 text-center text-gray-400 font-medium">등록된 상품이 없습니다.</td></tr>
             ) : (
               products.map((product) => (
-                <tr key={product.id} className="hover:bg-[#ba9470]/5 transition-colors">
-                  <td className="px-8 py-5 whitespace-nowrap text-sm text-gray-500 font-medium">#{product.id}</td>
+                <tr key={product.id || product.id} className="hover:bg-[#ba9470]/5 transition-colors">
+                  <td className="px-8 py-5 whitespace-nowrap text-sm text-gray-500 font-medium">#{product.id || product.id}</td>
                   <td className="px-8 py-5 whitespace-nowrap text-sm font-bold text-[#222222]">{product.name}</td>
                   <td className="px-8 py-5 whitespace-nowrap text-sm text-gray-600">{product.price.toLocaleString()}원</td>
                   <td className="px-8 py-5 whitespace-nowrap">
                     {product.stock > 0 ? (
-                      <span className="px-3 py-1 text-xs font-bold bg-[#ba9470]/10 text-[#ba9470] rounded-md">
-                        재고 있음 ({product.stock})
-                      </span>
+                      <span className="px-3 py-1 text-xs font-bold bg-[#ba9470]/10 text-[#ba9470] rounded-md">재고 있음 ({product.stock})</span>
                     ) : (
-                      <span className="px-3 py-1 text-xs font-bold bg-gray-100 text-gray-400 rounded-md">
-                        품절
-                      </span>
+                      <span className="px-3 py-1 text-xs font-bold bg-gray-100 text-gray-400 rounded-md">품절</span>
                     )}
                   </td>
                   <td className="px-8 py-5 whitespace-nowrap text-sm font-bold space-x-6 text-center">
@@ -134,6 +147,61 @@ export default function AdminProductsPage() {
           </tbody>
         </table>
       </div>
+
+      {/* 상품 등록 모달 (isModalOpen이 true일 때만 렌더링) */}
+      {isModalOpen && (
+        <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 animate-fadeIn">
+          <div className="bg-white p-8 rounded-2xl w-[400px] shadow-2xl">
+            <h3 className="text-2xl font-bold text-[#222222] mb-6">새 원두 등록</h3>
+            <form onSubmit={handleSubmit} className="space-y-5">
+              <div>
+                <label className="block text-sm font-bold text-gray-700 mb-2">상품명</label>
+                <input
+                  type="text" required placeholder="예: 콜롬비아 수프리모"
+                  className="w-full border border-gray-200 rounded-lg p-3 bg-gray-50 focus:bg-white focus:ring-2 focus:ring-[#ba9470] focus:border-transparent outline-none transition-all"
+                  value={newProduct.name}
+                  onChange={(e) => setNewProduct({ ...newProduct, name: e.target.value })}
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-sm font-bold text-gray-700 mb-2">가격 (원)</label>
+                  <input
+                    type="number" required placeholder="0" min="0"
+                    className="w-full border border-gray-200 rounded-lg p-3 bg-gray-50 focus:bg-white focus:ring-2 focus:ring-[#ba9470] focus:border-transparent outline-none transition-all"
+                    value={newProduct.price}
+                    onChange={(e) => setNewProduct({ ...newProduct, price: e.target.value })}
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-bold text-gray-700 mb-2">초기 재고 (개)</label>
+                  <input
+                    type="number" required placeholder="0" min="0"
+                    className="w-full border border-gray-200 rounded-lg p-3 bg-gray-50 focus:bg-white focus:ring-2 focus:ring-[#ba9470] focus:border-transparent outline-none transition-all"
+                    value={newProduct.stock}
+                    onChange={(e) => setNewProduct({ ...newProduct, stock: e.target.value })}
+                  />
+                </div>
+              </div>
+              <div className="flex space-x-3 pt-4">
+                <button
+                  type="button"
+                  onClick={() => setIsModalOpen(false)} // 닫기버튼
+                  className="flex-1 py-3 bg-gray-100 text-gray-600 rounded-lg font-bold hover:bg-gray-200 transition-colors"
+                >
+                  취소
+                </button>
+                <button
+                  type="submit"
+                  className="flex-1 py-3 bg-[#ba9470] text-white rounded-lg font-bold hover:bg-[#a67c52] transition-colors shadow-lg shadow-[#ba9470]/20"
+                >
+                  등록하기
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 📌 관련 이슈

Closes #76 

## 🛠️ 작업 내용
- **Modal UI 구현** 
Tailwind CSS 활용하여 배경 블러 처리(`backdrop-blur-sm`)와 포커스 효과를 적용한 모달 창 제작

- **Form State 관리** 
`newProduct` 객체 상태를 만들어 폼 입력값을 실시간으로 관리

- **API 연동 & 데이터 동기화** 
`POST /api/v1/admin/products` 성공 시, 모달을 닫고 `fetchProducts()`를 재호출하여 화면 새로고침 없이 테이블에 최신 데이터가 반영되도록 UX 개선

- **목록 조회 버그 수정** 
백엔드 컨트롤러의 기본 페이지 사이즈 제한(4개)으로 인해 발생하던 노출 제한 문제를 `size=100` 파라미터 전달을 통해 해결


- **상품 등록 유효성 검사**
상품명이 숫자로만 이루어진 경우를 식별하여 등록을 차단하는 정규식 검증 로직 추가

- **모달 UX 개선**
모달 취소 시 또는 등록 완료 후 입력 폼(`newProduct`)을 명시적으로 초기화하여 재사용 시 이전 데이터가 남지 않도록 처리

## 🎯 리뷰 포인트
- 상품 등록 후 데이터가 자연스럽게 추가되는지 확인 부탁드립니다.
- `fetchProducts`에서 타임스탬프(`t=${timestamp}`)와 `size=100`을 함께 사용한 방식이 백엔드 페이징 로직과 부합하는지 확인 부탁드립니다.
- 수정/삭제 기능은 현재 UI만 존재하며, 이번 PR 승인 후 별도 작업을 통해 수정할 예정입니다.

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
<img width="506" height="420" alt="새 원두 등록" src="https://github.com/user-attachments/assets/53287383-8504-4b74-81f3-1b56e411dbf5" />
<img width="489" height="433" alt="새 원두 등록" src="https://github.com/user-attachments/assets/9a6e769e-8d6b-4cfe-9849-d23ee8a31dee" />
<img width="1316" height="956" alt="Grids   Circies" src="https://github.com/user-attachments/assets/52c0c40f-d8cf-45df-bc20-7c68e6d50f74" />


## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?