### PR TITLE
feat: 관리자 상품 목록 개별 삭제 기능 구현 (#83)

### DIFF
--- a/frontend/src/app/admin/products/page.tsx
+++ b/frontend/src/app/admin/products/page.tsx
@@ -90,6 +90,29 @@ export default function AdminProductsPage() {
     }
   };
 
+  // 상품 삭제
+  const handleDelete = async (id: number) => {
+    if (!window.confirm('정말 상품을 삭제하시겠습니까?')) {
+      return; // 취소 가능
+    }
+
+    try {
+      const response = await fetch(`http://localhost:8080/api/v1/admin/products/${id}`, {
+        method: 'DELETE',
+      });
+
+      if (response.ok) {
+        alert('상품이 성공적으로 삭제되었습니다!');
+        fetchProducts();    // 목록 최신화
+      } else {
+        alert('상품 삭제에 실패했습니다.');
+      }
+    } catch (err) {
+      console.error('삭제 에러:', err);
+      alert('서버와 통신 중 에러가 발생했습니다.');
+    }
+  };
+
   if (isLoading && products.length === 0) {
     return (
       <div className="flex justify-center items-center h-64">
@@ -146,7 +169,12 @@ export default function AdminProductsPage() {
                     </td>
                     <td className="px-8 py-5 whitespace-nowrap text-sm font-bold space-x-6 text-center">
                       <button className="text-gray-300 cursor-not-allowed" disabled title="추후 구현 예정">수정</button>
-                      <button className="text-gray-300 cursor-not-allowed" disabled title="추후 구현 예정">삭제</button>
+                      <button
+                        onClick={() => handleDelete(pId as number)}
+                        className="text-gray-400 hover:text-red-500 transition-colors"
+                      >
+                        삭제
+                      </button>
                     </td>
                   </tr>
                 );


### PR DESCRIPTION
## 📌 관련 이슈

Closes #83

## 🛠️ 작업 내용
- **삭제 확인 로직** 
사용자의 조작 실수를 방지하기 위해 `window.confirm`을 사용하여 삭제 의사를 재확인하는 방어 로직 추가
- **API 연동** 
백엔드의 `DELETE /api/v1/admin/products/{id}` 엔드포인트와 연동하여 실제 DB의 데이터 삭제
- **동기화 UX** 
삭제 통신이 성공(`response.ok`)하면 `fetchProducts()`를 즉시 재호출하여, 화면 새로고침 없이 사용자 화면에서 삭제된 상품이 바로 사라지도록 처리


## 🎯 리뷰 포인트


## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
<img width="987" height="319" alt="Pasted Graphic 5" src="https://github.com/user-attachments/assets/aa8baa1b-a824-48e8-bb6d-d79846effd61" />
<img width="994" height="317" alt="35,000원" src="https://github.com/user-attachments/assets/646e8559-4b05-4ff2-ab22-0f9e45e85805" />
<img width="988" height="249" alt="파나아 케이시" src="https://github.com/user-attachments/assets/a133487a-db0a-496e-be49-f79b0d5d4cec" />

## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?