### PR TITLE
fix: 주문 성공 영수증 레이아웃 버그 수정 및 예외 처리 (#91)

### DIFF
--- a/frontend/src/app/components/OrderForm.tsx
+++ b/frontend/src/app/components/OrderForm.tsx
@@ -54,7 +54,7 @@ export default function OrderForm() {
         const itemsSummary = products
           .filter(p => cart[p.id] > 0)
           .map(p => `${p.name} x${cart[p.id]}:${(p.price * cart[p.id]).toLocaleString()}원`)
-          .join(',');
+          .join('|');
 
         router.push(`/orders/success?totalPrice=${totalAmount}&items=${itemsSummary}`);
       } else {

--- a/frontend/src/app/orders/success/page.tsx
+++ b/frontend/src/app/orders/success/page.tsx
@@ -9,19 +9,18 @@ export default function OrderSuccessPage() {
   // URL 파라미터에서 데이터 추출
   const totalPrice = searchParams.get('totalPrice') || '0';
   
-  // 주문 상품 목록 파싱 (예: "에티오피아 예가체프 x2:30,000원,과테말라 안티구아 x1:14,000원")
+  // 주문 상품 목록 파싱
   const itemsParam = searchParams.get('items'); 
   const orderItems = itemsParam 
-    ? itemsParam.split(',') 
-    : ['에티오피아 예가체프 x2:30,000원', '과테말라 안티구아 x1:14,000원'];
+    ? itemsParam.split('|') 
+    : ['에티오피아 예가체프 x3:45,000원', '콜롬비아 수프리모 x1:13,000원'];
 
   return (
-    // 배경을 어둡게 처리하여 모달 느낌을 살림
     <div className="flex items-center justify-center min-h-[calc(100vh-65px)] bg-black/10 p-6 font-sans">
       <div className="w-full max-w-sm bg-white rounded-2xl shadow-xl overflow-hidden animate-in fade-in zoom-in duration-300">
         <div className="p-8 flex flex-col items-center">
           
-          {/* 1. 상단 체크 아이콘 (사진의 녹색 원형 체크) */}
+          {/* 1. 상단 체크 아이콘 */}
           <div className="w-16 h-16 bg-[#ebf7ed] rounded-full flex items-center justify-center mb-6">
             <div className="w-10 h-10 bg-[#4caf50] rounded-full flex items-center justify-center text-white text-xl">
               ✓
@@ -32,34 +31,42 @@ export default function OrderSuccessPage() {
           <h2 className="text-xl font-bold text-gray-900 mb-2">주문이 완료되었습니다</h2>
           <p className="text-sm text-gray-600 mb-8">주문해 주셔서 감사합니다</p>
 
-          {/* 3. 첫 번째 구분선 */}
           <hr className="w-full border-gray-100 mb-6" />
 
-          {/* 4. 상품별 목록 (왼쪽: 상품명x수량, 오른쪽: 가격) */}
+          {/* 4. 상품별 목록 (핵심 수정 영역) */}
           <div className="w-full space-y-4 mb-6">
             {orderItems.map((item, index) => {
               const [label, price] = item.includes(':') ? item.split(':') : [item, ''];
               return (
-                <div key={index} className="flex justify-between items-center text-sm">
-                  <span className="text-gray-700">{label}</span>
-                  <span className="text-gray-900 font-medium">{price}</span>
+                <div key={index} className="flex justify-between items-start gap-4 text-sm">
+                  {/* 상품명 영역: flex-grow로 남은 공간을 채우고 leading-relaxed로 가독성 확보 */}
+                  <span className="text-gray-700 leading-relaxed">{label}</span>
+                  
+                  {/* 금액 영역: 
+                      - whitespace-nowrap: 절대 줄바꿈 방지 (45,000원 한 줄 유지)
+                      - flex-shrink-0: 상품명이 길어져도 금액 영역이 찌그러지지 않음
+                      - font-bold: 영수증 느낌을 위해 굵게 처리
+                  */}
+                  <span className="text-gray-900 font-bold whitespace-nowrap flex-shrink-0">
+                    {price}
+                  </span>
                 </div>
               );
             })}
           </div>
 
-          {/* 5. 두 번째 구분선 */}
           <hr className="w-full border-gray-100 mb-6" />
 
-          {/* 6. 총 합계 (사진처럼 굵게 표시) */}
+          {/* 6. 총 합계 */}
           <div className="w-full flex justify-between items-center mb-10">
             <span className="text-base font-bold text-gray-900">총 합계</span>
-            <span className="text-lg font-bold text-gray-900">
+            {/* 총 합계도 줄바꿈 방지 적용 */}
+            <span className="text-lg font-bold text-gray-900 whitespace-nowrap">
               {Number(totalPrice.replace(/[^0-9]/g, '')).toLocaleString()}원
             </span>
           </div>
 
-          {/* 7. 닫기 버튼 (라운드 처리된 깔끔한 버튼) */}
+          {/* 7. 닫기 버튼 */}
           <Link
             href="/"
             className="w-full py-3 border border-gray-200 text-gray-600 font-medium rounded-xl hover:bg-gray-50 transition-all text-center"

--- a/frontend/src/app/orders/success/page.tsx
+++ b/frontend/src/app/orders/success/page.tsx
@@ -9,11 +9,9 @@ export default function OrderSuccessPage() {
   // URL 파라미터에서 데이터 추출
   const totalPrice = searchParams.get('totalPrice') || '0';
   
-  // 주문 상품 목록 파싱
+  // 주문 상품 목록 파싱 (데이터가 없으면 빈 배열로 초기화)
   const itemsParam = searchParams.get('items'); 
-  const orderItems = itemsParam 
-    ? itemsParam.split('|') 
-    : ['에티오피아 예가체프 x3:45,000원', '콜롬비아 수프리모 x1:13,000원'];
+  const orderItems = itemsParam ? itemsParam.split('|') : [];
 
   return (
     <div className="flex items-center justify-center min-h-[calc(100vh-65px)] bg-black/10 p-6 font-sans">
@@ -33,26 +31,27 @@ export default function OrderSuccessPage() {
 
           <hr className="w-full border-gray-100 mb-6" />
 
-          {/* 4. 상품별 목록 (핵심 수정 영역) */}
+          {/* 4. 상품별 목록 (내역 없음 처리 추가) */}
           <div className="w-full space-y-4 mb-6">
-            {orderItems.map((item, index) => {
-              const [label, price] = item.includes(':') ? item.split(':') : [item, ''];
-              return (
-                <div key={index} className="flex justify-between items-start gap-4 text-sm">
-                  {/* 상품명 영역: flex-grow로 남은 공간을 채우고 leading-relaxed로 가독성 확보 */}
-                  <span className="text-gray-700 leading-relaxed">{label}</span>
-                  
-                  {/* 금액 영역: 
-                      - whitespace-nowrap: 절대 줄바꿈 방지 (45,000원 한 줄 유지)
-                      - flex-shrink-0: 상품명이 길어져도 금액 영역이 찌그러지지 않음
-                      - font-bold: 영수증 느낌을 위해 굵게 처리
-                  */}
-                  <span className="text-gray-900 font-bold whitespace-nowrap flex-shrink-0">
-                    {price}
-                  </span>
-                </div>
-              );
-            })}
+            {orderItems.length === 0 ? (
+              // URL에 상품 정보가 없을 경우 보여줄 Fallback UI
+              <div className="py-4 text-center">
+                <p className="text-sm text-gray-400">주문 내역을 불러올 수 없습니다.</p>
+              </div>
+            ) : (
+              // 정상적으로 상품 정보가 있을 경우 렌더링
+              orderItems.map((item, index) => {
+                const [label, price] = item.includes(':') ? item.split(':') : [item, ''];
+                return (
+                  <div key={index} className="flex justify-between items-start gap-4 text-sm">
+                    <span className="text-gray-700 leading-relaxed">{label}</span>
+                    <span className="text-gray-900 font-bold whitespace-nowrap flex-shrink-0">
+                      {price}
+                    </span>
+                  </div>
+                );
+              })
+            )}
           </div>
 
           <hr className="w-full border-gray-100 mb-6" />
@@ -60,7 +59,6 @@ export default function OrderSuccessPage() {
           {/* 6. 총 합계 */}
           <div className="w-full flex justify-between items-center mb-10">
             <span className="text-base font-bold text-gray-900">총 합계</span>
-            {/* 총 합계도 줄바꿈 방지 적용 */}
             <span className="text-lg font-bold text-gray-900 whitespace-nowrap">
               {Number(totalPrice.replace(/[^0-9]/g, '')).toLocaleString()}원
             </span>


### PR DESCRIPTION
## 📌 관련 이슈
> PR과 연관된 이슈 번호를 작성해주세요.  
> PR 머지 시 이슈를 닫으려면 `Closes #번호` 형식으로 작성해주세요. ex) `Closes #2`

Closes #91

## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.
- [x] 영수증 레이아웃 수정: 금액 텍스트에 `whitespace-nowrap`을 적용하여 강제 줄바꿈 방지, `flex-shrink-0`을 적용하여 상품명이 길어져도 금액 영역이 찌그러지지 않도록 보호
- [x] 데이터 파싱 버그 해결: 가격 데이터(`toLocaleString()`)에 포함된 콤마(`,`) 때문에 배열이 잘못 쪼개지는 버그 수정, `OrderForm.tsx`와 `success/page.tsx` 간의 데이터 구분자를 콤마(`,`)에서 파이프(`|`)로 변경
- [x] 예외 처리: URL 파라미터에 상품 데이터(`items`)가 비어있을 경우 "주문 내역을 불러올 수 없습니다"라는 안내 메시지를 렌더링하도록 안전장치 마련


## 🎯 리뷰 포인트
> 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요.
- 전체적인 흐름을 건드린 것이 없는지 확인 부탁드립니다.
- 가격 잘 정렬되는지 확인 부탁드립니다.


## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
<img width="490" height="717" alt="image" src="https://github.com/user-attachments/assets/028a9781-3f5c-4a0f-b6eb-3e48ba3b0614" />

## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?