### PR TITLE
feat: Spring Security, JWT(0.12.6) 인증 시스템 구축 및 로그인 API 구현 #88

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -35,6 +35,12 @@ dependencies {
 	testImplementation("org.springframework.boot:spring-boot-starter-validation-test")
 	testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+	// Spring Security
+	implementation("org.springframework.boot:spring-boot-starter-security")
+	// JWT(0.12.6)
+	implementation("io.jsonwebtoken:jjwt-api:0.12.6")
+	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.6")
+	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")
 }
 
 tasks.withType<Test> {

--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/entity/Member.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/entity/Member.java
@@ -25,6 +25,13 @@ public class Member {
     @Column(nullable = false, length = 20)
     private Role role = Role.USER;
 
+    // 관리자 계정 생성용
+    public Member(String email, String password, Role role) {
+        this.email = email;
+        this.password = password;
+        this.role = role;
+    }
+
     public Member(String email) {
         this.email = email;
     }

--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/global/config/InitDb.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/global/config/InitDb.java
@@ -1,0 +1,35 @@
+package com.gridsandcircles.gc_coffee.global.config;
+
+import com.gridsandcircles.gc_coffee.entity.Member;
+import com.gridsandcircles.gc_coffee.entity.Role;
+import com.gridsandcircles.gc_coffee.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class InitDb implements CommandLineRunner {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public void run(String... args) {
+        // DB에 admin 계정이 없는 경우에만 실행
+        if (memberRepository.findByEmail("admin@test.com").isEmpty()) {
+
+            Member admin = new Member(
+                    "admin@test.com",
+                    passwordEncoder.encode("1234"),
+                    Role.ADMIN
+            );
+
+            memberRepository.save(admin);
+            log.info("초기 관리자 계정이 생성되었습니다. (admin@test.com / 1234)");
+        }
+    }
+}

--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/global/config/SecurityConfig.java
@@ -1,0 +1,50 @@
+package com.gridsandcircles.gc_coffee.global.config;
+
+import com.gridsandcircles.gc_coffee.global.jwt.JwtFilter;
+import com.gridsandcircles.gc_coffee.global.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtProvider jwtProvider;
+
+    // 비밀번호 암호화
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public org.springframework.security.web.SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                // CSRF 설정 끄기 (Rest API로 불필요)
+                .csrf(AbstractHttpConfigurer::disable)
+
+                // 세션 사용 X (JWT 기반으로 STATELESS 설정)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                // 요청 권한 설정
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/v1/products/**").permitAll() // 상품 조회는 누구나 가능
+                        .requestMatchers("/api/v1/admin/**").hasAuthority("ADMIN") // 관리자 API는 ADMIN만 가능
+                        .anyRequest().authenticated() // 그 외 모든 요청은 인증 필요
+                )
+
+                // JWT 필터를 시큐리티 필터 체인에 등록
+                .addFilterBefore(new JwtFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/global/config/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
                 // 요청 권한 설정
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/v1/products/**").permitAll() // 상품 조회는 누구나 가능
+                        .requestMatchers("/api/v1/members/login").permitAll()
                         .requestMatchers("/api/v1/admin/**").hasAuthority("ADMIN") // 관리자 API는 ADMIN만 가능
                         .anyRequest().authenticated() // 그 외 모든 요청은 인증 필요
                 )

--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/global/exception/ErrorCode.java
@@ -21,7 +21,8 @@ public enum ErrorCode {
     ORDER_BATCH_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER_BATCH_NOT_FOUND", "배송 회차를 찾을 수 없습니다"),
 
     // 고객
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_NOT_FOUND", "고객을 찾을 수 없습니다");
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_NOT_FOUND", "고객을 찾을 수 없습니다"),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "INVALID_PASSWORD", "비밀번호가 일치하지 않습니다");
 
     private final HttpStatus status;
     private final String code;

--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/global/jwt/JwtFilter.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/global/jwt/JwtFilter.java
@@ -1,0 +1,56 @@
+package com.gridsandcircles.gc_coffee.global.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtFilter extends GenericFilterBean {
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    private final JwtProvider jwtProvider;
+
+    // 실제 필터링 로직: 요청이 들어올 때마다 실행
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+            throws IOException, ServletException {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
+
+        // 요청 헤더에서 JWT 토큰 추출
+        String jwt = resolveToken(httpServletRequest);
+        String requestURI = httpServletRequest.getRequestURI();
+
+        // 토큰 유효성 검사
+        if (StringUtils.hasText(jwt) && jwtProvider.validateToken(jwt)) {
+            // 유효하면 토큰에서 인증 정보(Authentication) 꺼내서 시큐리티 컨텍스트에 저장
+            Authentication authentication = jwtProvider.getAuthentication(jwt);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            log.debug("Security Context에 '{}' 인증 정보를 저장했습니다, uri: {}", authentication.getName(), requestURI);
+        } else {
+            log.debug("유효한 JWT 토큰이 없습니다, uri: {}", requestURI);
+        }
+
+        filterChain.doFilter(servletRequest, servletResponse);
+    }
+
+    // Request Header에서 토큰 정보를 꺼내는 메소드
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        // "Bearer "로 시작하는지 확인하고 토큰 값만 자름
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/global/jwt/JwtProvider.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/global/jwt/JwtProvider.java
@@ -1,0 +1,96 @@
+package com.gridsandcircles.gc_coffee.global.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+    @Slf4j
+    @Component
+    public class JwtProvider implements InitializingBean {
+
+        private static final String AUTHORITIES_KEY = "auth";
+
+        private final String secret;
+        private final long tokenValidityInMilliseconds;
+        private Key key;
+
+        // application.yaml에 세팅한 환경변수 값 가져오기
+        public JwtProvider(
+                @Value("${jwt.secret}") String secret,
+                @Value("${jwt.token-validity-in-seconds}") long tokenValidityInSeconds) {
+            this.secret = secret;
+            this.tokenValidityInMilliseconds = tokenValidityInSeconds * 1000;
+        }
+
+        // 빈 생성 -> 의존성 주입 -> 비밀키 암호화 키로 변경(Base64 디코딩)
+        @Override
+        public void afterPropertiesSet() {
+            byte[] keyBytes = Decoders.BASE64.decode(secret);
+            this.key = Keys.hmacShaKeyFor(keyBytes);
+        }
+
+        // 토큰 생성(로그인 성공 시 실행)
+        public String createToken(Authentication authentication) {
+            String authorities = authentication.getAuthorities().stream()
+                                               .map(GrantedAuthority::getAuthority)
+                                               .collect(Collectors.joining(","));
+
+            long now = (new Date()).getTime();
+            Date validity = new Date(now + this.tokenValidityInMilliseconds);
+
+            return Jwts.builder()
+                       .subject(authentication.getName())      // 토큰 제목 (이메일)
+                       .claim(AUTHORITIES_KEY, authorities)    // 권한 정보 (예: ROLE_ADMIN)
+                       .signWith(key)
+                       .expiration(validity)                   // 만료 시간
+                       .compact();
+        }
+
+        // 토큰 복호화 및 인증 객체(Authentication) 반환
+        public Authentication getAuthentication(String token) {
+            Claims claims = Jwts.parser()
+                                .verifyWith((SecretKey) key)
+                                .build()
+                                .parseSignedClaims(token)
+                                .getPayload();
+
+            Collection<? extends GrantedAuthority> authorities =
+                    Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+                          .map(SimpleGrantedAuthority::new)
+                          .collect(Collectors.toList());
+
+            org.springframework.security.core.userdetails.User principal =
+                    new org.springframework.security.core.userdetails.User(claims.getSubject(), "", authorities);
+
+            return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+        }
+
+        // 토큰 유효성 검증
+        public boolean validateToken(String token) {
+            try {
+                Jwts.parser().verifyWith((SecretKey) key).build().parseSignedClaims(token);
+                return true;
+            } catch (JwtException | IllegalArgumentException e) {
+                log.info("유효하지 않은 JWT 토큰입니다: {}", e.getMessage());
+            }
+            return false;
+        }
+    }
+

--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/member/controller/MemberController.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/member/controller/MemberController.java
@@ -1,8 +1,10 @@
 package com.gridsandcircles.gc_coffee.member.controller;
 
 import com.gridsandcircles.gc_coffee.global.dto.ApiResponse;
+import com.gridsandcircles.gc_coffee.member.dto.LoginRequest;
 import com.gridsandcircles.gc_coffee.member.dto.MemberRequest;
 import com.gridsandcircles.gc_coffee.member.dto.MemberResponse;
+import com.gridsandcircles.gc_coffee.member.dto.TokenResponse;
 import com.gridsandcircles.gc_coffee.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -16,12 +18,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class MemberController {
 
-    private final MemberService memberservice;
+    private final MemberService memberService;
 
     @PostMapping
     public ApiResponse<MemberResponse> createOrFindMember(
             @RequestBody @Valid MemberRequest request){
-        MemberResponse response = memberservice.findOrCreateMember(request);
+        MemberResponse response = memberService.findOrCreateMember(request);
         return ApiResponse.ok(response);
+    }
+
+    @PostMapping("/login")
+    public ApiResponse<TokenResponse> login(@RequestBody @Valid LoginRequest loginRequest) {
+        return ApiResponse.ok(memberService.login(loginRequest));
     }
 }

--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/member/dto/LoginRequest.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/member/dto/LoginRequest.java
@@ -1,0 +1,11 @@
+package com.gridsandcircles.gc_coffee.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank(message = "이메일은 필수 입력 값입니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+        String password
+) {}

--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/member/dto/TokenResponse.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/member/dto/TokenResponse.java
@@ -1,0 +1,4 @@
+package com.gridsandcircles.gc_coffee.member.dto;
+
+public class TokenResponse {
+}

--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/member/dto/TokenResponse.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/member/dto/TokenResponse.java
@@ -1,4 +1,10 @@
 package com.gridsandcircles.gc_coffee.member.dto;
 
-public class TokenResponse {
+public record TokenResponse(
+        String accessToken,
+        String tokenType
+) {
+    public static TokenResponse of(String accessToken) {
+        return new TokenResponse(accessToken, "Bearer");
+    }
 }

--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/member/service/MemberService.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/member/service/MemberService.java
@@ -1,18 +1,31 @@
 package com.gridsandcircles.gc_coffee.member.service;
 
 import com.gridsandcircles.gc_coffee.entity.Member;
+import com.gridsandcircles.gc_coffee.global.exception.BusinessException;
+import com.gridsandcircles.gc_coffee.global.exception.ErrorCode;
+import com.gridsandcircles.gc_coffee.global.jwt.JwtProvider;
+import com.gridsandcircles.gc_coffee.member.dto.LoginRequest;
 import com.gridsandcircles.gc_coffee.member.dto.MemberRequest;
 import com.gridsandcircles.gc_coffee.member.dto.MemberResponse;
+import com.gridsandcircles.gc_coffee.member.dto.TokenResponse;
 import com.gridsandcircles.gc_coffee.member.repository.MemberRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final JwtProvider jwtProvider;
+    private final PasswordEncoder passwordEncoder;
 
     @Transactional
     public MemberResponse findOrCreateMember(MemberRequest request){
@@ -23,4 +36,28 @@ public class MemberService {
 
         return MemberResponse.from(member);
     }
+
+
+    @Transactional
+    public TokenResponse login(LoginRequest loginRequest) {
+        // 이메일로 회원 조회
+        Member member = memberRepository.findByEmail(loginRequest.email())
+                                        .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        // 비밀번호 일치 확인 (암호화된 비밀번호와 비교)
+        if (!passwordEncoder.matches(loginRequest.password(), member.getPassword())) {
+            throw new BusinessException(ErrorCode.INVALID_PASSWORD);
+        }
+
+        // 인증 객체 생성 및 토큰 발급
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                member.getEmail(),
+                null,
+                List.of(new SimpleGrantedAuthority(member.getRole().name()))
+        );
+
+        String token = jwtProvider.createToken(authentication);
+        return TokenResponse.of(token);
+    }
+
 }

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -24,3 +24,8 @@ spring:
 
 server:
   port: 8080
+
+jwt:
+  # 환경변수 JWT_SECRET 읽어오기. 값 없으면 에러남
+  secret: ${JWT_SECRET}
+  token-validity-in-seconds: 86400


### PR DESCRIPTION
## 📌 관련 이슈

Closes #88 

## 🛠️ 작업 내용

- **의존성 추가** 
Spring Security 및 `jjwt` 0.12.6 최신 버전 적용

- **보안 설정**
`application.yaml` 내 JWT 비밀키를 하드코딩하지 않고 환경변수(`JWT_SECRET`)로 주입받도록 처리

- **인증 코어 구현** 
  - 토큰 발급 및 검증을 담당하는 `JwtProvider` 구현 (0.12.6 문법 적용)
  - HTTP 요청 헤더에서 토큰을 추출해 유효성을 검사하는 `JwtFilter` 구현

- **SecurityConfig 설정** 
`/api/v1/admin/**` 경로에 대해 `ADMIN` 권한을 요구하도록 라우팅 보호 및 `BCryptPasswordEncoder` 빈 등록

- **로그인 API 연동**
  - `LoginRequest`, `TokenResponse` DTO 생성
  - `MemberService.login` 로직 작성 (비밀번호 검증 및 토큰 발급)
  - `MemberController`에 `POST /api/v1/members/login` 엔드포인트 추가
  - 비밀번호 불일치 시 사용할 `INVALID_PASSWORD` 커스텀 에러 코드 추가

- **initDB**
서버 실행 시 관리자 계정 생성



## 🎯 리뷰 포인트
- 로컬 환경에서 서버를 띄울 때 반드시 IDE 환경변수에 `JWT_SECRET` 값을 세팅해야 정상 가동됩니다.
- 포스트맨에서 토큰 발급, 관리자 페이지 접근 가능한지 확인 부탁드립니다. 

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)

## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?