### PR TITLE
feat: 로그인 페이지 및 JWT 통신 모듈 구현 (#94)

### DIFF
--- a/backend/src/main/java/com/gridsandcircles/gc_coffee/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/gridsandcircles/gc_coffee/global/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.gridsandcircles.gc_coffee.global.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -37,6 +38,7 @@ public class SecurityConfig {
 
                 // 요청 권한 설정
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/api/v1/products/**").permitAll() // 상품 조회는 누구나 가능
                         .requestMatchers("/api/v1/members/login").permitAll()
                         .requestMatchers("/api/v1/admin/**").hasAuthority("ADMIN") // 관리자 API는 ADMIN만 가능

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -1,13 +1,34 @@
 'use client';
 
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
-import React from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import React, { useState, useEffect } from 'react';
 
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
     const pathname = usePathname();
-
+    const router = useRouter();
+    const [isAuthorized, setIsAuthorized] = useState(false);
     const isActive = (href: string) => pathname.startsWith(href);
+
+    useEffect(() => {
+        const token = localStorage.getItem('accessToken');
+        if (!token) {
+            alert('관리자 권한이 필요합니다. 먼저 로그인해주세요.');
+            router.replace('/login');
+        } else {
+            setIsAuthorized(true);
+        }
+    }, [router]);
+
+    const handleLogout = () => {
+        localStorage.removeItem('accessToken');
+        alert('로그아웃 되었습니다.');
+        router.push('/login');
+    };
+
+    if (!isAuthorized) {
+        return null;
+    }
 
     return (
         <div className="flex h-screen bg-[#f8f9fa] font-sans">
@@ -57,7 +78,12 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
                     <h2 className="text-xl font-bold text-[#222222]">
                         {isActive('/admin/products') ? '📦 상품 관리' : '🛒 주문 관리'}
                     </h2>
-                    <button className="text-sm font-bold text-[#ba9470] hover:underline">로그아웃</button>
+                    <button
+                        onClick={handleLogout}
+                        className="text-sm font-bold text-[#ba9470] hover:underline"
+                    >
+                        로그아웃
+                    </button>
                 </header>
                 <div className="flex-1 overflow-y-auto p-10 bg-white">
                     <div className="max-w-6xl mx-auto">{children}</div>

--- a/frontend/src/app/admin/products/page.tsx
+++ b/frontend/src/app/admin/products/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { Product, ApiResponse } from '@/app/type/product';
+import { customFetch } from '@/app/api/customFetch';
 
 export default function AdminProductsPage() {
   const [products, setProducts] = useState<Product[]>([]);
@@ -19,7 +20,7 @@ export default function AdminProductsPage() {
       setIsLoading(true);
       const timestamp = new Date().getTime();
       // size=100으로 백엔드의 4개 제한을 우회하고, t파라미터로 캐시 방지
-      const response = await fetch(`http://localhost:8080/api/v1/products?size=100&t=${timestamp}`, {
+      const response = await customFetch(`/api/v1/products?size=100&t=${timestamp}`, {
         cache: 'no-store',
       });
 
@@ -85,12 +86,12 @@ export default function AdminProductsPage() {
       return;
     }
     const url = editingId
-      ? `http://localhost:8080/api/v1/admin/products/${editingId}`
-      : `http://localhost:8080/api/v1/admin/products`;
+      ? `/api/v1/admin/products/${editingId}`
+      : `/api/v1/admin/products`;
     const method = editingId ? 'PUT' : 'POST';
 
     try {
-      const response = await fetch(url, {
+      const response = await customFetch(url, {
         method: method,
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -120,7 +121,7 @@ export default function AdminProductsPage() {
     }
 
     try {
-      const response = await fetch(`http://localhost:8080/api/v1/admin/products/${id}`, {
+      const response = await customFetch(`/api/v1/admin/products/${id}`, {
         method: 'DELETE',
       });
 

--- a/frontend/src/app/api/customFetch.ts
+++ b/frontend/src/app/api/customFetch.ts
@@ -1,0 +1,28 @@
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
+
+export async function customFetch(endpoint: string, options: RequestInit = {}) {
+  const headers = new Headers(options.headers);
+  headers.set('Content-Type', 'application/json');
+
+  if (typeof window !== 'undefined') {
+    const token = localStorage.getItem('accessToken');
+    if (token) {
+      headers.set('Authorization', `Bearer ${token}`);
+    }
+  }
+
+  const response = await fetch(`${BASE_URL}${endpoint}`, {
+    ...options,
+    headers,
+  });
+
+  if (response.status === 401 && !endpoint.includes('/login')) {
+    if (typeof window !== 'undefined') {
+      alert('인증이 만료되었습니다. 다시 로그인해주세요.');
+      localStorage.removeItem('accessToken');
+      window.location.href = '/login';
+    }
+  }
+
+  return response;
+}

--- a/frontend/src/app/context/AuthContext.tsx
+++ b/frontend/src/app/context/AuthContext.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { useRouter } from 'next/navigation';
+
+interface AuthContextType {
+    isLoggedIn: boolean;
+    login: (token: string) => void;
+    logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+    const [isLoggedIn, setIsLoggedIn] = useState(false);
+    const router = useRouter();
+
+    useEffect(() => {
+        const token = localStorage.getItem('accessToken');
+        setIsLoggedIn(!!token);
+    }, []);
+
+    const login = (token: string) => {
+        localStorage.setItem('accessToken', token);
+        setIsLoggedIn(true);
+        router.push('/admin');
+    };
+
+    const logout = () => {
+        localStorage.removeItem('accessToken');
+        setIsLoggedIn(false);
+        alert('로그아웃 되었습니다.');
+        router.push('/login');
+    };
+
+    return (
+        <AuthContext.Provider value={{ isLoggedIn, login, logout }}>
+            {children}
+        </AuthContext.Provider>
+    );
+}
+
+export function useAuth() {
+    const context = useContext(AuthContext);
+    if (context === undefined) {
+        throw new Error('useAuth must be used within an AuthProvider');
+    }
+    return context;
+}

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { customFetch } from '../api/customFetch';
+
+export default function LoginPage() {
+    const router = useRouter();
+    const [email, setEmail] = useState('');
+    const [password, setPassword] = useState('');
+    const [errorMsg, setErrorMsg] = useState('');
+
+    const handleLogin = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setErrorMsg('');
+
+        try {
+            const response = await customFetch('/api/members/login', {
+                method: 'POST',
+                body: JSON.stringify({ email, password }),
+            });
+
+            if (!response.ok) {
+                throw new Error('로그인 실패');
+            }
+
+            const data = await response.json();
+            const { accessToken } = data;
+
+            localStorage.setItem('accessToken', accessToken);
+            alert('로그인에 성공했습니다!');
+            router.push('/admin');
+
+        } catch (error: any) {
+            console.error('Login failed:', error);
+            setErrorMsg('아이디 또는 비밀번호가 올바르지 않습니다.');
+        }
+    };
+
+    return (
+        <div className="flex justify-center items-center min-h-screen bg-gray-100">
+            <form onSubmit={handleLogin} className="bg-white p-8 rounded shadow-md w-96">
+                <h2 className="text-2xl font-bold mb-6 text-center text-gray-800">로그인</h2>
+
+                {errorMsg && (
+                    <div className="mb-4 text-red-500 text-sm text-center">{errorMsg}</div>
+                )}
+
+                <div className="mb-4">
+                    <label className="block text-gray-700 text-sm font-bold mb-2">이메일</label>
+                    <input
+                        type="email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        className="w-full px-3 py-2 border rounded text-gray-700 focus:outline-none focus:border-blue-500"
+                        required
+                    />
+                </div>
+
+                <div className="mb-6">
+                    <label className="block text-gray-700 text-sm font-bold mb-2">비밀번호</label>
+                    <input
+                        type="password"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        className="w-full px-3 py-2 border rounded text-gray-700 focus:outline-none focus:border-blue-500"
+                        required
+                    />
+                </div>
+
+                <button
+                    type="submit"
+                    className="w-full bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded focus:outline-none"
+                >
+                    로그인
+                </button>
+            </form>
+        </div>
+    );
+}

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -15,7 +15,7 @@ export default function LoginPage() {
         setErrorMsg('');
 
         try {
-            const response = await customFetch('/api/members/login', {
+            const response = await customFetch('/api/v1/members/login', {
                 method: 'POST',
                 body: JSON.stringify({ email, password }),
             });
@@ -24,12 +24,14 @@ export default function LoginPage() {
                 throw new Error('로그인 실패');
             }
 
-            const data = await response.json();
-            const { accessToken } = data;
+            const result = await response.json();
+
+            const { accessToken } = result.data;
 
             localStorage.setItem('accessToken', accessToken);
             alert('로그인에 성공했습니다!');
-            router.push('/admin');
+
+            window.location.href = '/admin';
 
         } catch (error: any) {
             console.error('Login failed:', error);


### PR DESCRIPTION
## 📌 관련 이슈
Closes #94 

## 🛠️ 작업 내용
- [x] 로그인 UI 컴포넌트 및 페이지 구현

- [x] 상품 관리 페이지 JWT 통신 모듈 구현

- [x] fetch->customFetch 교체(인증 헤더 자동 주입)

- [x] 하드코딩된 서버주소 제거 및 상대 경로 적용


## 🎯 리뷰 포인트
> 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요.
- 리뷰 포인트


## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
<img width="420" height="379" alt="image" src="https://github.com/user-attachments/assets/17258ff6-5274-4b1a-be39-a3b211f09d10" />
<img width="475" height="370" alt="image" src="https://github.com/user-attachments/assets/c25eb223-6641-444d-b9d5-5fa464b899c7" />

## ✅ 체크리스트
- [ ] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [ ] 팀의 코딩 컨벤션을 준수했나요?
- [ ] 로컬에서 충분히 테스트를 진행했나요?